### PR TITLE
increase file size limit

### DIFF
--- a/vault-web-server/postapi/fileupload.go
+++ b/vault-web-server/postapi/fileupload.go
@@ -23,8 +23,8 @@ type UploadResponse struct {
 	FailedFileNames     map[string]string `json:"failed_file_names"`
 }
 
-const MAX_FILE_SIZE int64 = 3 << 20         // 3 MB
-const MAX_TOTAL_UPLOAD_SIZE int64 = 3 << 20 // 3 MB
+const MAX_FILE_SIZE int64 = 16 << 20         // 16 MB
+const MAX_TOTAL_UPLOAD_SIZE int64 = 25 << 20 // 25 MB
 
 func UploadHandler(w http.ResponseWriter, r *http.Request) {
 


### PR DESCRIPTION
As a sentient human looking for real answers, I need a way to a book which is 15MB as rtf. Currently the limits on the live website are too low, in my opinion.