### PR TITLE
Update "postinstall" to force a bash shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "vault core website",
   "main": "index.js",
   "scripts": {
-    "start": "source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server && echo && ./bin/vault-web-server",
+    "start": "bash -c './scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server && echo && ./bin/vault-web-server'",
     "dev": "webpack --progress --watch",
     "postinstall": "bash -c 'source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server'"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server && echo && ./bin/vault-web-server",
     "dev": "webpack --progress --watch",
-    "postinstall": "source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server"
+    "postinstall": "bash -c 'source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
"postinstall": "source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server" >  "postinstall": "bash -c 'source ./scripts/source-me.sh && ./scripts/go-compile.sh ./vault-web-server'"

'source' command not recognised when running 'npm install' in Ubuntu 22.10; updating "postinstall" to use 'bash -c' instead of 'source', to force npm to use bash.

Apologies for any mistakes. Long time lurker, first time contributor.