### PR TITLE
Alternate vector databases (qdrant)

### DIFF
--- a/chunk/fileprocessing.go
+++ b/chunk/fileprocessing.go
@@ -1,4 +1,4 @@
-package postapi
+package chunk
 
 import (
 	"errors"
@@ -94,7 +94,7 @@ func CreateChunks(fileContent string, title string) ([]Chunk, error) {
 	return chunks, nil
 }
 
-func getTextFromFile(f multipart.File) (string, error) {
+func GetTextFromFile(f multipart.File) (string, error) {
 	fileBytes, err := ioutil.ReadAll(f)
 	if err != nil {
 		return "", err
@@ -112,7 +112,7 @@ func getTextFromFile(f multipart.File) (string, error) {
 }
 
 // extract human-readable text from a given pdf with support for spaces/whitespace.
-func extractTextFromPDF(f multipart.File, fileSize int64) (string, error) {
+func ExtractTextFromPDF(f multipart.File, fileSize int64) (string, error) {
 	// Reset the file reader's position
 	_, err := f.Seek(0, io.SeekStart)
 	if err != nil {

--- a/scripts/source-me.sh
+++ b/scripts/source-me.sh
@@ -17,7 +17,7 @@ export GOPATH="$HOME/go"
 export PATH="$PATH:$PWD/bin:$PWD/tools/protoc-3.6.1/bin"
 export DOCKER_BUILDKIT=1
 export OPENAI_API_KEY="$(cat ${secrets_path}/openai_api_key)"
-export PINECONE_API_KEY="$(cat ${secrets_path}/pinecone_api_key)"
-export PINECONE_API_ENDPOINT="$(cat ${secrets_path}/pinecone_api_endpoint)"
+export PINECONE_API_KEY="$(cat ${secrets_path}/pinecone_api_key 2>/dev/null)"
+export PINECONE_API_ENDPOINT="$(cat ${secrets_path}/pinecone_api_endpoint 2>/dev/null)"
 
 echo "=> Environment Variables Loaded"

--- a/vault-web-server/postapi/fileupload.go
+++ b/vault-web-server/postapi/fileupload.go
@@ -109,7 +109,7 @@ func (ctx *HandlerContext) UploadHandler(w http.ResponseWriter, r *http.Request)
 		}
 		log.Printf("File Name: %s, File Type: %s, File Content (first 32 characters): %s\n", fileName, fileType, filePreview)
 
-		// Process the fileBytes into embeddings and store in Pinecone here
+		// Process the fileBytes into embeddings and store in vector DB here
 		chunks, err := chunk.CreateChunks(fileContent, fileName)
 		if err != nil {
 			errMsg := "Error chunking file"
@@ -131,17 +131,16 @@ func (ctx *HandlerContext) UploadHandler(w http.ResponseWriter, r *http.Request)
 		fmt.Printf("Total embeddings: %d\n", len(embeddings))
 		fmt.Printf("Embeddings length: %d\n", len(embeddings[0]))
 
-		// Call the upsertEmbeddingsToPinecone function
 		err = ctx.vectorDB.UpsertEmbeddings(embeddings, chunks, uuid)
 		if err != nil {
-			errMsg := fmt.Sprintf("Error upserting embeddings to Pinecone: %v", err)
+			errMsg := fmt.Sprintf("Error upserting embeddings to vector DB: %v", err)
 			log.Println("[UploadHandler ERR]", errMsg)
 			responseData.NumFilesFailed++
 			responseData.FailedFileNames[fileName] = errMsg
 			continue
 		}
 
-		log.Println("Successfully added pinecone embeddings!")
+		log.Println("Successfully added vector DB embeddings!")
 
 		responseData.NumFilesSucceeded++
 		responseData.SuccessfulFileNames = append(responseData.SuccessfulFileNames, fileName)

--- a/vault-web-server/postapi/fileupload.go
+++ b/vault-web-server/postapi/fileupload.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/pashpashpash/vault/chunk"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -20,7 +21,7 @@ type UploadResponse struct {
 const MAX_FILE_SIZE int64 = 3 << 20         // 3 MB
 const MAX_TOTAL_UPLOAD_SIZE int64 = 3 << 20 // 3 MB
 
-func UploadHandler(w http.ResponseWriter, r *http.Request) {
+func (ctx *HandlerContext) UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Limit the request body size
 	r.Body = http.MaxBytesReader(w, r.Body, MAX_TOTAL_UPLOAD_SIZE)
@@ -44,7 +45,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("[UploadHandler] UUID=", uuid)
 
-	clientToUse := DEFAULT_OPENAI_CLIENT
+	clientToUse := ctx.openAIClient
 	if userProvidedOpenApiKey != "" {
 		log.Println("[UploadHandler] Using provided custom API key:", userProvidedOpenApiKey)
 		clientToUse = openai.NewClient(userProvidedOpenApiKey)
@@ -84,7 +85,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Check if the file is a PDF
 		if fileType == "application/pdf" {
-			fileContent, err = extractTextFromPDF(f, file.Size)
+			fileContent, err = chunk.ExtractTextFromPDF(f, file.Size)
 			if err != nil {
 				errMsg := "Error extracting text from PDF"
 				log.Println("[UploadHandler ERR]", errMsg, err)
@@ -93,7 +94,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 		} else {
-			fileContent, err = getTextFromFile(f)
+			fileContent, err = chunk.GetTextFromFile(f)
 			if err != nil {
 				errMsg := "Error reading file"
 				log.Println("[UploadHandler ERR]", errMsg, err)
@@ -109,7 +110,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("File Name: %s, File Type: %s, File Content (first 32 characters): %s\n", fileName, fileType, filePreview)
 
 		// Process the fileBytes into embeddings and store in Pinecone here
-		chunks, err := CreateChunks(fileContent, fileName)
+		chunks, err := chunk.CreateChunks(fileContent, fileName)
 		if err != nil {
 			errMsg := "Error chunking file"
 			log.Println("[UploadHandler ERR]", errMsg, err)
@@ -131,7 +132,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("Embeddings length: %d\n", len(embeddings[0]))
 
 		// Call the upsertEmbeddingsToPinecone function
-		err = upsertEmbeddingsToPinecone(embeddings, chunks, uuid)
+		err = ctx.vectorDB.UpsertEmbeddings(embeddings, chunks, uuid)
 		if err != nil {
 			errMsg := fmt.Sprintf("Error upserting embeddings to Pinecone: %v", err)
 			log.Println("[UploadHandler ERR]", errMsg)

--- a/vault-web-server/postapi/formparseverify.go
+++ b/vault-web-server/postapi/formparseverify.go
@@ -6,34 +6,10 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/gorilla/schema"
 	"github.com/pashpashpash/vault/errorlist"
 	"github.com/pashpashpash/vault/form"
-	"github.com/pashpashpash/vault/serverutil"
-
-	"github.com/gorilla/schema"
-	cache "github.com/patrickmn/go-cache"
-	openai "github.com/sashabaranov/go-openai"
 )
-
-var (
-	CONFIG                = serverutil.GetConfig()
-	C                     *cache.Cache
-	DEFAULT_OPENAI_CLIENT         *openai.Client
-	PINECONE_API_KEY      = ""
-	PINECONE_API_ENDPOINT = ""
-)
-
-type Config struct {
-	Debug bool
-}
-
-// Must be called to set up this module before use
-func Run(openaiClient *openai.Client, pineconeApiKey string, pineconeApiEndpoint string) {
-	C = cache.New(cache.NoExpiration, cache.NoExpiration)
-	DEFAULT_OPENAI_CLIENT = openaiClient
-	PINECONE_API_KEY = pineconeApiKey
-	PINECONE_API_ENDPOINT = pineconeApiEndpoint
-}
 
 // Util: does grunt work of decoding + verifying form + writing errors back
 func FormParseVerify(form form.Form, name string, w http.ResponseWriter, r *http.Request) errorlist.Errors {

--- a/vault-web-server/postapi/handlercontext.go
+++ b/vault-web-server/postapi/handlercontext.go
@@ -1,0 +1,22 @@
+package postapi
+
+import (
+	"github.com/pashpashpash/vault/vectordb"
+
+	cache "github.com/patrickmn/go-cache"
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type HandlerContext struct {
+	openAIClient *openai.Client
+	cache        *cache.Cache
+	vectorDB     vectordb.VectorDB
+}
+
+func NewHandlerContext(openAIClient *openai.Client, vectorDB vectordb.VectorDB) *HandlerContext {
+	return &HandlerContext{
+		openAIClient: openAIClient,
+		cache:        cache.New(cache.NoExpiration, cache.NoExpiration),
+		vectorDB:     vectorDB,
+	}
+}

--- a/vault-web-server/postapi/openai.go
+++ b/vault-web-server/postapi/openai.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pashpashpash/vault/chunk"
 	"github.com/pkoukk/tiktoken-go"
 	openai "github.com/sashabaranov/go-openai"
 )
@@ -132,7 +133,7 @@ func callEmbeddingAPIWithRetry(client *openai.Client, texts []string, embedModel
 	return nil, err
 }
 
-func getEmbeddings(client *openai.Client, chunks []Chunk, batchSize int,
+func getEmbeddings(client *openai.Client, chunks []chunk.Chunk, batchSize int,
 	embedModel openai.EmbeddingModel) ([][]float32, error) {
 	embeddings := make([][]float32, 0, len(chunks))
 

--- a/vault-web-server/postapi/questions.go
+++ b/vault-web-server/postapi/questions.go
@@ -21,7 +21,7 @@ type Answer struct {
 }
 
 // Handle Requests For Question
-func QuestionHandler(w http.ResponseWriter, r *http.Request) {
+func (ctx *HandlerContext) QuestionHandler(w http.ResponseWriter, r *http.Request) {
 	form := new(form.QuestionForm)
 
 	if errs := FormParseVerify(form, "QuestionForm", w, r); errs != nil {
@@ -33,7 +33,7 @@ func QuestionHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("[QuestionHandler] UUID:", form.UUID)
 	log.Println("[QuestionHandler] ApiKey:", form.ApiKey)
 
-	clientToUse := DEFAULT_OPENAI_CLIENT
+	clientToUse := ctx.openAIClient
 	if form.ApiKey != "" {
 		log.Println("[QuestionHandler] Using provided custom API key:", form.ApiKey)
 		clientToUse = openai.NewClient(form.ApiKey)
@@ -49,7 +49,7 @@ func QuestionHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("[QuestionHandler] Question Embedding Length:", len(questionEmbedding))
 
 	// step 2: Query Pinecone using questionEmbedding to get context matches
-	matches, err := retrieve(questionEmbedding, 4, form.UUID)
+	matches, err := ctx.vectorDB.Retrieve(questionEmbedding, 4, form.UUID)
 	if err != nil {
 		log.Println("[QuestionHandler ERR] Pinecone query error\n", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/vault-web-server/postapi/questions.go
+++ b/vault-web-server/postapi/questions.go
@@ -48,15 +48,15 @@ func (ctx *HandlerContext) QuestionHandler(w http.ResponseWriter, r *http.Reques
 	}
 	log.Println("[QuestionHandler] Question Embedding Length:", len(questionEmbedding))
 
-	// step 2: Query Pinecone using questionEmbedding to get context matches
+	// step 2: Query vector db using questionEmbedding to get context matches
 	matches, err := ctx.vectorDB.Retrieve(questionEmbedding, 4, form.UUID)
 	if err != nil {
-		log.Println("[QuestionHandler ERR] Pinecone query error\n", err.Error())
+		log.Println("[QuestionHandler ERR] Vector DB query error\n", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	log.Println("[QuestionHandler] Got matches from Pinecone:", matches)
+	log.Println("[QuestionHandler] Got matches from vector DB:", matches)
 
 	// Extract context text and titles from the matches
 	contexts := make([]Context, len(matches))
@@ -64,9 +64,9 @@ func (ctx *HandlerContext) QuestionHandler(w http.ResponseWriter, r *http.Reques
 		contexts[i].Text = match.Metadata["text"]
 		contexts[i].Title = match.Metadata["title"]
 	}
-	log.Println("[QuestionHandler] Retrieved context from Pinecone:\n", contexts)
+	log.Println("[QuestionHandler] Retrieved context from vector DB:\n", contexts)
 
-	// step 3: Structure the prompt with a context section + question, using top x results from pinecone as the context
+	// step 3: Structure the prompt with a context section + question, using top x results from vector DB as the context
 	contextTexts := make([]string, len(contexts))
 	for i, context := range contexts {
 		contextTexts[i] = context.Text

--- a/vectordb/pinecone/pinecone.go
+++ b/vectordb/pinecone/pinecone.go
@@ -27,7 +27,7 @@ type Pinecone struct {
 	ApiKey   string
 }
 
-func New(apiKey string, endpoint string) (*Pinecone, error) {
+func New(endpoint string, apiKey string) (*Pinecone, error) {
 	return &Pinecone{
 		Endpoint: endpoint,
 		ApiKey:   apiKey,

--- a/vectordb/qdrant/qdrant.go
+++ b/vectordb/qdrant/qdrant.go
@@ -1,0 +1,215 @@
+package qdrant
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pashpashpash/vault/chunk"
+	"github.com/pashpashpash/vault/vectordb"
+	cache "github.com/patrickmn/go-cache"
+)
+
+const (
+	VECTOR_SIZE     = 1536 // ada002
+	VECTOR_DISTANCE = "Cosine"
+)
+
+type Qdrant struct {
+	Endpoint string
+	cache    *cache.Cache
+}
+
+type Point struct {
+	ID      int               `json:"id"`
+	Vector  []float32         `json:"vector"`
+	Payload map[string]string `json:"payload,omitempty"`
+}
+
+type Match struct {
+	ID      int               `json:"id"`
+	Score   float32           `json:"score"`
+	Payload map[string]string `json:"payload"`
+	Version int               `json:"version"`
+}
+
+type SearchResult struct {
+	Result []Match `json:"result"`
+	Status string  `json:"status"`
+	Time   float64 `json:"time"`
+}
+
+type NamespaceConfig struct {
+	Vectors struct {
+		Size     int    `json:"size"`
+		Distance string `json:"distance"`
+	} `json:"vectors"`
+}
+
+func New(endpoint string) (*Qdrant, error) {
+	return &Qdrant{
+		Endpoint: endpoint,
+		cache:    cache.New(5*time.Minute, 10*time.Minute),
+	}, nil
+}
+
+func (q *Qdrant) NamespaceExists(uuid string) (bool, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/collections/%s", q.Endpoint, uuid), nil)
+	if err != nil {
+		return false, err
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	} else if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		_, _ = resp.Body.Read(body)
+		return false, fmt.Errorf("failed to check namespace, status code: %d, %s", resp.StatusCode, body)
+	}
+
+	return true, nil
+}
+
+func (q *Qdrant) CreateNamespace(uuid string) error {
+	if _, found := q.cache.Get(uuid); found {
+		return nil
+	}
+
+	if exists, err := q.NamespaceExists(uuid); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+
+	config := NamespaceConfig{}
+	config.Vectors.Size = VECTOR_SIZE
+	config.Vectors.Distance = VECTOR_DISTANCE
+
+	jsonData, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/collections/%s", q.Endpoint, uuid), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to create namespace, status code: %d", resp.StatusCode)
+	}
+
+	q.cache.Set(uuid, true, cache.DefaultExpiration)
+
+	return nil
+}
+
+func (q *Qdrant) UpsertEmbeddings(embeddings [][]float32, chunks []chunk.Chunk, uuid string) error {
+	if err := q.CreateNamespace(uuid); err != nil {
+		return err
+	}
+
+	points := make([]Point, len(embeddings))
+
+	for i, embedding := range embeddings {
+		points[i].ID = i
+		points[i].Vector = embedding
+		if i < len(chunks) {
+			points[i].Payload = map[string]string{
+				"start": fmt.Sprintf("%d", chunks[i].Start),
+				"end":   fmt.Sprintf("%d", chunks[i].End),
+				"title": chunks[i].Title,
+				"text":  chunks[i].Text,
+			}
+		}
+	}
+
+	data := map[string][]Point{"points": points}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("JSON data: %s\n", string(jsonData))
+
+	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/collections/%s/points?wait=true", q.Endpoint, uuid), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to upsert embeddings, status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (q *Qdrant) Retrieve(questionEmbedding []float32, topK int, uuid string) ([]vectordb.QueryMatch, error) {
+	data := map[string]interface{}{
+		"vector":       questionEmbedding,
+		"top":          topK,
+		"with_payload": true,
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/collections/%s/points/search", q.Endpoint, uuid), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to retrieve embeddings, status code: %d", resp.StatusCode)
+	}
+
+	var searchResult SearchResult
+	err = json.NewDecoder(resp.Body).Decode(&searchResult)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert qdrantMatch to QueryMatch
+	queryMatches := make([]vectordb.QueryMatch, len(searchResult.Result))
+	for i, result := range searchResult.Result {
+		queryMatches[i].ID = fmt.Sprintf("%d", result.ID)
+		queryMatches[i].Score = result.Score
+		queryMatches[i].Metadata = result.Payload
+	}
+
+	return queryMatches, nil
+}

--- a/vectordb/vectordb.go
+++ b/vectordb/vectordb.go
@@ -1,0 +1,16 @@
+package vectordb
+
+import (
+	"github.com/pashpashpash/vault/chunk"
+)
+
+type QueryMatch struct {
+	ID       string            `json:"id"`
+	Score    float32           `json:"score"` // Use "score" instead of "distance"
+	Metadata map[string]string `json:"metadata"`
+}
+
+type VectorDB interface {
+	UpsertEmbeddings(embeddings [][]float32, chunks []chunk.Chunk, uuid string) error
+	Retrieve(questionEmbedding []float32, topK int, uuid string) ([]QueryMatch, error)
+}


### PR DESCRIPTION
I wanted to try vault-ai but wanted to be able to run my vector database locally. `qdrant` seemed reasonable and was very easy to get set up (`cargo run` pretty much did it) so I gave that a shot.

Some notes:
* Made a `VectorDB` interface that exposes `UpsertEmbeddings` and `Retrieve`. This interface is pretty simplistic but was enough to get going and could be built out more later if other databases actually need more functionality
* Made a `HandlerContext` struct that holds the openai client and vectordb instance (whether an instance of pinecone or qdrant). It means that `main` can create the context which holds most of the state of the app and does not need global variables.
* qdrant API is close enough to pinecone's, but does not automatically create new collections. Added some code to check if the collection exists (looking at local cache first) and if not, create it.